### PR TITLE
Extract 3d image to slices

### DIFF
--- a/monai_ex/tests/test_Extract3DImageToSlices.py
+++ b/monai_ex/tests/test_Extract3DImageToSlices.py
@@ -1,0 +1,51 @@
+import pytest
+
+import numpy as np
+from monai_ex.transforms.croppad.array import Extract3DImageToSlices
+from monai_ex.transforms.croppad.dictionary import Extract3DImageToSlicesd
+from monai_ex.transforms import GenerateSyntheticData, GenerateSyntheticDataD
+
+def test_selectslicesbymask():
+    dim = 3
+    spatial_size = (100,) * dim
+
+    generator = GenerateSyntheticData(
+        *spatial_size,
+        num_objs=1,
+        rad_max=5,
+        rad_min=4,
+        noise_max=0,
+        num_seg_classes=1,
+        channel_dim=0,
+    )
+
+    image, label = generator(None)
+    cropper = Extract3DImageToSlices(z_axis=2)
+    img_slice = cropper(image)[0]
+
+    assert img_slice.shape == (1, 100, 100)
+
+
+def test_selectslicesbymaskdict():
+    dim = 3
+    spatial_size = (100,) * dim
+
+    generator = GenerateSyntheticDataD(
+        ["image", "label"],
+        *spatial_size,
+        num_objs=1,
+        rad_max=5,
+        rad_min=4,
+        noise_max=0,
+        num_seg_classes=1,
+        channel_dim=0,
+    )
+
+    outputs = generator({"image": "1", "label": "1"})
+    cropper = Extract3DImageToSlicesd(keys=["image", "label"], z_axis=2)
+
+    img_slice = cropper(outputs)
+
+    assert len(img_slice) == 100
+    assert img_slice[1]["image"].shape == (1, 100, 100)
+    assert img_slice[1]["label"].shape == (1, 100, 100)

--- a/monai_ex/transforms/croppad/array.py
+++ b/monai_ex/transforms/croppad/array.py
@@ -480,6 +480,11 @@ class RandCropByPosNegLabelEx(RandCropByPosNegLabel):
 
 class Extract3DImageToSlices(Transform):
     backend: SpatialCrop.backend
+    """Extract 3D image to slices along given axis.
+
+    Args:
+        z_axis (int): the index of z axis to extract slices.
+    """
 
     def __init__(self, z_axis: int) -> None:
         super().__init__()


### PR DESCRIPTION
Add transform `Extract3DImageToSlices` to extract all 2D slices from 3D data along given axis.
E.g. a data with size of (1, 64, 64, 32) will be processed to a list [(1, 64, 64), ... ] with length of 32.